### PR TITLE
Re-adds secrets.yml as remove breaks Devise in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,3 @@
 /react/coverage
 plans.md
 pseudocode.md
-secrets.yml
-/config/secrets.yml

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rails secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: 2dfecebaf7a71568820cefbef28c67788fb0e1893fcc09941e2bfc1e51553cc9ce550c423e540d1fbf9d05477887a08fe41d5d86563a902bf15fdf9ee23cb683
+
+test:
+  secret_key_base: 472566edbb681a1a75f40e8cb562dc41d8d7644a24f4997b2d6ce59a3ecb1fa522dcf6be7fe237ca206e9f0bf4f804ec6d4d11b563651ec174909b77723dc7b7
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
Re-adds secrets.yml file; I had removed it not realizing that Devise relies on it's secret key base switcheroo to work properly in production.